### PR TITLE
ci: remove `continue-on-error` flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
         run: npm run lint
 
       - name: Correr tests con cobertura
-        continue-on-error: true
-        run: npm test -- --coverage
+        run: npm test -- --coverage --coverageThreshold='{}'
 
       - name: Subir cobertura a Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Elimina el flag `continue-on-error` del CI porque potencialmente puede silenciar errores en los tests.